### PR TITLE
通知機能実装

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -5,6 +5,7 @@ class AccountActivationsController < ApplicationController
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
       log_in user
+      Notification::Welcome.send_welcome_notification(user)
       flash[:success] = "Account activated!"
       redirect_to user
     else

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,10 @@ class RelationshipsController < ApplicationController
 
   def create
     @user = User.find(params[:followed_id])
+    # フォロー＆通知の処理をサービスクラスに委譲しても良さそう
     current_user.follow(@user)
+    relationship = Relationship.find_by(followed: @user, follower: current_user)
+    Notification::Relationship.send_new_relationship_notification(relationship)
     respond_to do |format|
       format.html { redirect_to @user }
       format.js

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,6 @@
 class Notification < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
   belongs_to :user
+
+  scope :relationships, -> { where(notifiable_type: 'Relationship') }
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,4 @@
+class Notification < ApplicationRecord
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :user
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ApplicationRecord
-  belongs_to :notifiable, polymorphic: true
+  belongs_to :notifiable, polymorphic: true, optional: true
   belongs_to :user
 
   scope :relationships, -> { where(notifiable_type: 'Relationship') }

--- a/app/models/notification/relationship.rb
+++ b/app/models/notification/relationship.rb
@@ -1,0 +1,9 @@
+class Notification::Relationship < Notification
+  validates :user, presence: true
+
+  delegate :follower_name, to: :notifiable
+
+  def message
+    "#{follower_name}さんにフォローされました"
+  end
+end

--- a/app/models/notification/relationship.rb
+++ b/app/models/notification/relationship.rb
@@ -28,6 +28,11 @@ class Notification::Relationship < Notification
     def send_new_relationship_notification(relationship)
       followed = relationship.followed
 
+      recent_notification = followed.notifications.relationships.find_by(updated_at: 5.minutes.ago..)
+      if recent_notification
+        return recent_notification.increment_other_followers_count
+      end
+
       followed.notifications.create(
         notifiable: relationship,
         notifiable_type: relationship.class,

--- a/app/models/notification/relationship.rb
+++ b/app/models/notification/relationship.rb
@@ -6,4 +6,16 @@ class Notification::Relationship < Notification
   def message
     "#{follower_name}さんにフォローされました"
   end
+
+  class << self
+    def send_new_relationship_notification(relationship)
+      followed = relationship.followed
+
+      followed.notifications.create(
+        notifiable: relationship,
+        notifiable_type: relationship.class,
+        type: self
+      )
+    end
+  end
 end

--- a/app/models/notification/welcome.rb
+++ b/app/models/notification/welcome.rb
@@ -1,0 +1,13 @@
+class Notification::Welcome < Notification
+  validates :user, presence: true, uniqueness: true
+
+  def message
+    "初回ログインありがとうございます。"
+  end
+
+  class << self
+    def send_welcome_notification(user)
+      user.notifications.create(type: self)
+    end
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,4 +3,6 @@ class Relationship < ApplicationRecord
   belongs_to :followed, class_name: "User"
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+
+  delegate :name, to: :follower, prefix: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
                                    dependent:   :destroy
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
+  has_many :notifications
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email
   before_create :create_activation_digest

--- a/db/migrate/20220325020117_create_notifications.rb
+++ b/db/migrate/20220325020117_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.references :notifiable, polymorphic: true, index: true
+      t.references :user, null: false, foreign_key: true
+      t.string :type, index: true
+      t.boolean :checked
+      t.text :meta
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_032413) do
+ActiveRecord::Schema.define(version: 2022_03_25_020117) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,20 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.string "notifiable_type"
+    t.integer "notifiable_id"
+    t.integer "user_id", null: false
+    t.string "type"
+    t.boolean "checked"
+    t.text "meta"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["type"], name: "index_notifications_on_type"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "followed_id"
@@ -78,4 +92,5 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "microposts", "users"
+  add_foreign_key "notifications", "users"
 end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  notifiable: one
+  notifiable_type: Relationship
+  user: lana
+  type: Notification::Relationship
+  checked: false
+

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -7,3 +7,10 @@ one:
   type: Notification::Relationship
   checked: false
   meta: "{\"other_followers_count\":0}"
+
+two:
+  notifiable_type: Welcome
+  user: lana
+  type: Notification::Welcome
+  checked: false
+  

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -6,4 +6,4 @@ one:
   user: lana
   type: Notification::Relationship
   checked: false
-
+  meta: "{\"other_followers_count\":0}"

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -27,13 +27,13 @@ class FollowingTest < ActionDispatch::IntegrationTest
   end
 
   test "should follow a user the standard way" do
-    assert_difference '@user.following.count', 1 do
+    assert_difference ['@user.following.count', 'Notification::Relationship.count'], 1 do
       post relationships_path, params: { followed_id: @other.id }
     end
   end
 
   test "should follow a user with Ajax" do
-    assert_difference '@user.following.count', 1 do
+    assert_difference ['@user.following.count', 'Notification::Relationship.count'], 1 do
       post relationships_path, xhr: true, params: { followed_id: @other.id }
     end
   end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -47,4 +47,25 @@ class NotificationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  class Notification::WelcomeTest < self
+    def setup
+      @notification_welcome = notifications(:two)
+    end
+  
+    test "should be valid" do
+      assert @notification_welcome.valid?
+    end
+
+    test "#message: return welcome message" do
+      assert_equal @notification_welcome.message, "初回ログインありがとうございます。"
+    end
+
+    test ".send_welcome_notification: add a notification" do
+      user = users(:user_1)
+      assert_difference ['Notification::Welcome.count'], 1 do
+        notification = Notification::Welcome.send_welcome_notification(user)
+      end
+    end
+  end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -10,10 +10,20 @@ class NotificationTest < ActiveSupport::TestCase
       assert @notification_relationship.valid?
     end
 
-    test "return message when a user is followed" do
+    test "#message: return message when a user is followed" do
       relationship = @notification_relationship.notifiable
       follower_name = relationship.follower_name
       assert_equal @notification_relationship.message, "#{follower_name}さんにフォローされました"
+    end
+
+    test ".send_new_relationship_notification: add a notification" do
+      relationship = relationships(:one)
+      notification = nil
+      assert_difference ['Notification::Relationship.count'], 1 do
+        notification = Notification::Relationship.send_new_relationship_notification(relationship)
+      end
+      assert_equal notification.notifiable, relationship
+      assert_equal notification.user, relationship.followed
     end
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  class Notification::RelationshipTest < self
+    def setup
+      @notification_relationship = notifications(:one)
+    end
+  
+    test "should be valid" do
+      assert @notification_relationship.valid?
+    end
+
+    test "return message when a user is followed" do
+      relationship = @notification_relationship.notifiable
+      follower_name = relationship.follower_name
+      assert_equal @notification_relationship.message, "#{follower_name}さんにフォローされました"
+    end
+  end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -11,13 +11,20 @@ class NotificationTest < ActiveSupport::TestCase
     end
 
     test "#message: return message when a user is followed" do
-      relationship = @notification_relationship.notifiable
-      follower_name = relationship.follower_name
+      follower_name = @notification_relationship.notifiable.follower_name
       assert_equal @notification_relationship.message, "#{follower_name}さんにフォローされました"
     end
 
+    test "#message: message includes other followers count if exists other followers" do
+      other_followers_count = 2
+      @notification_relationship.meta = "{\"other_followers_count\":#{other_followers_count}}"
+
+      follower_name = @notification_relationship.notifiable.follower_name
+      assert_equal @notification_relationship.message, "#{follower_name}さん他#{other_followers_count}名にフォローされました"
+    end
+
     test ".send_new_relationship_notification: add a notification" do
-      relationship = relationships(:one)
+      relationship = relationships(:two)
       notification = nil
       assert_difference ['Notification::Relationship.count'], 1 do
         notification = Notification::Relationship.send_new_relationship_notification(relationship)


### PR DESCRIPTION
## 概要
以下二つの通知機能を実装しました

- フォローされた際の通知
- 初回ログイン時の通知

通知情報は`notifications`テーブルに保存し（STI）、messageメソッドを通じてそれぞれの通知内容を返します

## 詳細

### フォローされた際の通知
状況に応じて二種類のメッセージを生成します

**通常版メッセージ**
```
Notification::Relationship.last.message
=> "fukuさんにフォローされました"
```

**5分以内に複数人からフォローされた際のメッセージ**
```
Notification::Relationship.last.message
=> "fukuさん他2名にフォローされました"
```

### 初回ログイン時の通知

**初回ログイン時メッセージ**
```
Notification::Welcome.last.message
=> "初回ログインありがとうございます。"
```

### 一覧画面等を想定したポリモーフィックなアクセス
```
Notification.all.includes(notifiable: :user).each {|n| p n.message }
"初回ログインありがとうございます。"
"fukuさんにフォローされました"
"fukuさんにフォローされました"
"fukuさん他2名にフォローされました"
```

## 補足
今回のアプリはコードベースが小さかったため、責務を細分化しすぎないようにしました。
仮にコードベースが大きかった場合はデコレーターや専用テンプレートを用いて表示部分の責務を分けることや、サービスクラスを用いて一連のユースケースをまとめるなどの対応が適切だったかと考えております。